### PR TITLE
Removed repository meta data as dzil determines this any way

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,7 +31,4 @@ push_to     = origin              ; see Git::Push
 
 [MetaResources]
 homepage        = https://github.com/spazm/p5-dancer-plugin-authen-simple
-repository.web  = http://github.com/spazm/p5-dancer-plugin-authen-simple
-repository.url  = http://github.com/spazm/p5-dancer-plugin-authen-simple.git
-repository.type = git
 


### PR DESCRIPTION
Hi,
I'm looking at your module as part of the CPAN Pull Request Challenge. The first thing I noticed is that for forks of your repository the repository MetaResources configs error as the dzil git plugin (I think) this causes "dzil test" to die. I have removed those lines so forks work ok.

Ivan
